### PR TITLE
fix: activeTab Notice에서만 사용하도록 수정

### DIFF
--- a/src/pages/Notice/Notice/NoticeList/NoticeList.tsx
+++ b/src/pages/Notice/Notice/NoticeList/NoticeList.tsx
@@ -5,7 +5,6 @@ import type { NoticeItem as NoticeItemType } from "../../../../services/NoticeSe
 
 interface NoticeListProps {
   notices: NoticeItemType[];
-  activeTab: string;
   onItemClick: (noticeId: string) => void;
 }
 

--- a/src/pages/Notice/Search/Components/SearchResult/SearchResult.tsx
+++ b/src/pages/Notice/Search/Components/SearchResult/SearchResult.tsx
@@ -6,13 +6,11 @@ import searchresultIcon from "../../../../../assets/icon/notice/search/searchres
 
 interface SearchResultProps {
   filteredNotices: NoticeItem[];
-  activeTab: string;
   onItemClick: (noticeId: string) => void;
 }
 
 const SearchResult: React.FC<SearchResultProps> = ({
   filteredNotices,
-  activeTab,
   onItemClick,
 }) => {
   if (filteredNotices.length === 0) {
@@ -26,11 +24,7 @@ const SearchResult: React.FC<SearchResultProps> = ({
 
   return (
     <div className={styles.searchResult}>
-      <NoticeList
-        notices={filteredNotices}
-        activeTab={activeTab}
-        onItemClick={onItemClick}
-      />
+      <NoticeList notices={filteredNotices} onItemClick={onItemClick} />
     </div>
   );
 };

--- a/src/pages/Notice/Search/Search.tsx
+++ b/src/pages/Notice/Search/Search.tsx
@@ -155,7 +155,6 @@ const Search: React.FC = () => {
           />
           <SearchResult
             filteredNotices={filteredNotices}
-            activeTab="학사"
             onItemClick={navigateToNoticeDetail}
           />
         </>


### PR DESCRIPTION
activeTab 속성이 탭 필터링 기능인데, 굳이 다른 페이지에 필요없을 것 같아 Notice에서만 사용하도록 수정했습니다.