### PR TITLE
feat: [FocusedLocationBottomSheet] 위치 상세 정보 바텀시트 아래로 드래그 시 포커스 해제 기능 추가

### DIFF
--- a/src/components/Map/FocusedLocationBottomSheet/FocusedLocationBottomSheet.tsx
+++ b/src/components/Map/FocusedLocationBottomSheet/FocusedLocationBottomSheet.tsx
@@ -9,6 +9,7 @@ import { DetailPlaceData } from "../../../../types/mapTypes";
 interface FocusedLocationBottomSheetProps {
   hasFocusedMarker: boolean;
   isExpandedFocusedSheet: boolean;
+  setHasFocusedMarker: (value: boolean) => void;
   setIsExpandedFocusedSheet: (value: boolean) => void;
   detailLocationData: DetailPlaceData | null;
 }
@@ -16,6 +17,7 @@ interface FocusedLocationBottomSheetProps {
 const FocusedLocationBottomSheet: React.FC<FocusedLocationBottomSheetProps> = ({
   hasFocusedMarker,
   isExpandedFocusedSheet,
+  setHasFocusedMarker,
   setIsExpandedFocusedSheet,
   detailLocationData,
 }) => {
@@ -45,7 +47,9 @@ const FocusedLocationBottomSheet: React.FC<FocusedLocationBottomSheetProps> = ({
   useBottomSheetDrag({
     sheetRef,
     isExpanded: isExpandedFocusedSheet,
+    hasFocusedMarker: hasFocusedMarker,
     setIsExpanded: setIsExpandedFocusedSheet,
+    setHasFocusedMarker: setHasFocusedMarker,
     minHeight: 450,
   });
 

--- a/src/hooks/useBottomSheetDrag.ts
+++ b/src/hooks/useBottomSheetDrag.ts
@@ -3,14 +3,18 @@ import { useEffect, useRef } from "react";
 interface UseBottomSheetDragProps {
   sheetRef: React.RefObject<HTMLDivElement | null>;
   isExpanded: boolean;
+  hasFocusedMarker?: boolean;
   setIsExpanded: (value: boolean) => void;
+  setHasFocusedMarker?: (value: boolean) => void;
   minHeight: number; // 예: 150, 380 등
 }
 
 export default function useBottomSheetDrag({
   sheetRef,
   isExpanded,
+  hasFocusedMarker,
   setIsExpanded,
+  setHasFocusedMarker,
   minHeight,
 }: UseBottomSheetDragProps) {
   const startY = useRef(0);
@@ -86,6 +90,10 @@ export default function useBottomSheetDrag({
         sheet.style.transform = isExpanded
           ? "translateY(0)"
           : `translateY(calc(100% - ${minHeight}px))`;
+      }
+
+      if (!isExpanded && hasFocusedMarker && setHasFocusedMarker && diff > 80) {
+        setHasFocusedMarker(false);
       }
 
       isDragging.current = false;

--- a/src/pages/Map/MapPage.tsx
+++ b/src/pages/Map/MapPage.tsx
@@ -421,6 +421,7 @@ const MapPage = () => {
       <FocusedLocationBottomSheet
         hasFocusedMarker={hasFocusedMarker}
         isExpandedFocusedSheet={isExpandedFocusedSheet}
+        setHasFocusedMarker={setHasFocusedMarker}
         setIsExpandedFocusedSheet={setIsExpandedFocusedSheet}
         detailLocationData={detailLocationData}
       />


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 위치 상세 정보 바텀시트 아래로 드래그 시 포커스 해제 기능 추가
- useBottomSheetDrag에 선택적 props로 hasFocusedMarker와 setHasFocusedMarker 추가
특정 위치가 포커스된 상태에서 바텀시트가 확장되지 않을 경우, 시트를 드래그로 내리면 위치 포커스가 해제되도록 함
```tsx
if (!isExpanded && hasFocusedMarker && setHasFocusedMarker && diff > 80) {
   setHasFocusedMarker(false);
}
```
---

## 🔗 관련 이슈

closes #68 

---

## 📷 스크린샷 (필요한 경우)

- 바텀시트를 드래그해서 내리면 아래 이미지처럼 포커스된 형태의 마커는 남아있고 바텀 시트만 변경됨.

<img width="374" height="815" alt="image" src="https://github.com/user-attachments/assets/b69b335d-5087-4ee4-b043-2fa8a764ebca" />
<img width="374" height="816" alt="image" src="https://github.com/user-attachments/assets/ec234bd7-bde7-4626-9f07-ff2fe2abdc49" />

---

## 📋 체크리스트

- [ ] 상세 정보 바텀 시트 아래로 드래그 시 포커스 해제되도록 기능 추가

---

## 💬 하고 싶은 말

- 포커스된 형태의 마커를 원래 마커로 돌리는 것이 나을지 아니면 그대로 두는 것이 나을지 논의를 해야할 듯 함
