### PR TITLE
[Feat/#70] home friend location api

### DIFF
--- a/src/apis/map.ts
+++ b/src/apis/map.ts
@@ -24,6 +24,7 @@ const DELETE_RECENT_SEARCH = "/places/search/history/"; // 최근 검색어 하�
 interface IsSharedApiResponse extends ApiResponse {
   data: {
     isActive: boolean;
+    placeName: string | null;
   };
 }
 export const checkIsSharedApi = async () => {
@@ -31,7 +32,7 @@ export const checkIsSharedApi = async () => {
     const response = await axiosInstance.get<IsSharedApiResponse>(
       CHECK_SHARE_STATE_API
     );
-    return response.data.data.isActive; // 성공 응답 반환
+    return response.data.data; // 성공 응답 반환
   } catch (error: any) {
     console.error(
       "위치 공유 상태 확인 실패:",

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -22,6 +22,9 @@ const Home = () => {
   const navigate = useNavigate();
   // const [showSplash, setShowSplash] = useState(true);
   const [isSharedLocation, setIsSharedLocation] = useState(false); // 내 위치 공유상태인지 아닌지
+  const [sharedLocationName, setSharedLocationName] = useState<string | null>(
+    null
+  );
   const [hasNewAlarm, setHasNewAlarm] = useState(false); // 새로운 알람이 있는지
   // 공유 상태 확인 트리거 키
   const [locationSharedRefreshKey, setLocationSharedRefreshKey] = useState(0);
@@ -47,7 +50,8 @@ const Home = () => {
     try {
       const response = await checkIsSharedApi();
       console.log("현재 내 위치 공유 상태 : ", response);
-      setIsSharedLocation(response);
+      setIsSharedLocation(response.isActive);
+      setSharedLocationName(response.placeName);
     } catch (error) {
       console.error("위치 공유 상태 확인 실패 : ", error);
     }
@@ -104,11 +108,11 @@ const Home = () => {
             isSharedLocation={isSharedLocation}
             setModalState={setShareModalState}
             currentLocation={currentLocation}
-            nearLocation={nearLocation}
+            sharedLocationName={sharedLocationName}
             setNearLocation={setNearLocation}
           />
         )}
-        <FriendLocation isSharedLocation={isSharedLocation} />
+        <FriendLocation userSharedLocation={sharedLocationName} />
         <MyLocationRanking updateTrigger={tryToRerender} />
         <HomeNotice />
       </div>

--- a/src/pages/Home/components/FriendLocation/FriendLocation.module.css
+++ b/src/pages/Home/components/FriendLocation/FriendLocation.module.css
@@ -59,7 +59,6 @@
 }
 .HighlightBorder {
   box-shadow: 0 0 0 1px #009733;
-  /* border: 1px solid var(--Brand-Primary_1, #009733); */
   border-radius: 10px;
 }
 .EachLocationTitleWrapper {

--- a/src/pages/Home/components/FriendLocation/FriendLocation.tsx
+++ b/src/pages/Home/components/FriendLocation/FriendLocation.tsx
@@ -3,76 +3,23 @@ import { useNavigate } from "react-router-dom";
 
 import arrowRight from "@assets/nav/arrowRight.svg";
 import locationIcon from "@assets/icon/locationIcon.png";
-import defaulProfileImg from "@assets/defaultProfileImg.svg";
-import exampleProfileImg1 from "@assets/exampleProfileImg1.png";
-import exampleProfileImg2 from "@assets/exampleProfileImg2.png";
-import exampleProfileImg3 from "@assets/exampleProfileImg3.png";
+import DefaultProfileImg from "@assets/defaultProfileImg.svg";
+import { PlaceData } from "@/shared/types";
 
 import styles from "./FriendLocation.module.css";
 import { getCategoryLocationsApi } from "@/apis/map";
 
-const dummyFriendLocationData = [
-  {
-    location: "상허기념도서관",
-    friends: [
-      {
-        nickname: "김쿠룸",
-        profileImg: defaulProfileImg,
-      },
-      {
-        nickname: "박쿠룸",
-        profileImg: exampleProfileImg1,
-      },
-      {
-        nickname: "최쿠룸",
-        profileImg: defaulProfileImg,
-      },
-      {
-        nickname: "이쿠룸",
-        profileImg: defaulProfileImg,
-      },
-      {
-        nickname: "송쿠룸",
-        profileImg: defaulProfileImg,
-      },
-    ],
-  },
-  {
-    location: "제1 학생회관",
-    friends: [
-      {
-        nickname: "김쿠룸",
-        profileImg: exampleProfileImg2,
-      },
-      {
-        nickname: "박쿠룸",
-        profileImg: defaulProfileImg,
-      },
-    ],
-  },
-  {
-    location: "경영관",
-    friends: [
-      {
-        nickname: "백쿠룸",
-        profileImg: defaulProfileImg,
-      },
-      {
-        nickname: "신쿠룸",
-        profileImg: exampleProfileImg3,
-      },
-    ],
-  },
-];
-
 interface FriendLocationProps {
-  isSharedLocation: boolean;
+  userSharedLocation: string | null;
 }
 
 const FriendLocation: React.FC<FriendLocationProps> = ({
-  isSharedLocation,
+  userSharedLocation,
 }) => {
   const navigate = useNavigate();
+  const [friendSharedLocationData, setFriendSharedLocationData] = useState<
+    PlaceData[]
+  >([]);
   // 화면 너비에 따라 개수 다르게 보이기. 크기에 따라 최대 3 혹은 4개
   const [maxVisibleFriends, setMaxVisibleFriends] = useState(4);
 
@@ -80,6 +27,7 @@ const FriendLocation: React.FC<FriendLocationProps> = ({
     try {
       const response = await getCategoryLocationsApi("FRIEND");
       console.log("위치 공유한 친구 배열 : ", response);
+      setFriendSharedLocationData(response);
     } catch (error) {
       console.error("위치 공유한 친구 배열 조회 중 오류 : ", error);
     }
@@ -104,73 +52,72 @@ const FriendLocation: React.FC<FriendLocationProps> = ({
   };
 
   return (
-    <div className={styles.FriendLocationContentWrapper}>
-      <div className={styles.FriendLocationSectionTitle}>
-        <div className={styles.TitleWrapper}>
-          <h1 className={styles.SectionTitleBold}>친구 위치 공유</h1>
-          <span className={styles.NormalText}>
-            친구들이 어디에 있는지 알려드릴게요 :)
-          </span>
-        </div>
-        <img
-          className={styles.ArrowButton}
-          src={arrowRight}
-          alt="자세히 보기"
-          onClick={handleClickArrow}
-        />
-      </div>
-
-      {dummyFriendLocationData.map((item, index) => {
-        const shouldShowMore = item.friends.length > maxVisibleFriends;
-        const visibleFriends = item.friends.slice(0, maxVisibleFriends);
-
-        return (
-          <div
-            key={index}
-            className={`${styles.EachLocationWrapper} ${
-              isSharedLocation && item.location === "상허기념도서관"
-                ? styles.HighlightBorder
-                : ""
-            }`}
-          >
-            <div className={styles.EachLocationTitleWrapper}>
-              <img
-                className={styles.LocationIcon}
-                src={locationIcon}
-                alt="핀포인트 아이콘"
-              />
-              <h1 className={styles.EachLocationTitle}>{item.location}</h1>
-            </div>
-
-            <div className={styles.LocationFriendWrapper}>
-              {visibleFriends.map((friend, index) => (
-                <div key={index} className={styles.EachFriendProfile}>
-                  <img
-                    style={{ width: "49px", height: "49px" }}
-                    src={friend.profileImg}
-                    alt="프로필 사진"
-                  />
-                  <span className={styles.Nickname}>{friend.nickname}</span>
-                </div>
-              ))}
-
-              {shouldShowMore && (
-                <button
-                  className={styles.EachFriendProfile}
-                  onClick={() => console.log("더보기 클릭")}
-                >
-                  <div className={styles.LearnMoreWrapper}>
-                    <div className={styles.Dotstyle} />
-                    <div className={styles.Dotstyle} />
-                    <div className={styles.Dotstyle} />
-                  </div>
-                </button>
-              )}
-            </div>
+    friendSharedLocationData.length > 0 && (
+      <div className={styles.FriendLocationContentWrapper}>
+        <div className={styles.FriendLocationSectionTitle}>
+          <div className={styles.TitleWrapper}>
+            <h1 className={styles.SectionTitleBold}>친구 위치 공유</h1>
+            <span className={styles.NormalText}>
+              친구들이 어디에 있는지 알려드릴게요 :)
+            </span>
           </div>
-        );
-      })}
-    </div>
+          <img
+            className={styles.ArrowButton}
+            src={arrowRight}
+            alt="자세히 보기"
+            onClick={handleClickArrow}
+          />
+        </div>
+
+        {friendSharedLocationData.map((item, index) => {
+          const shouldShowMore = item.friends.length > maxVisibleFriends;
+          const visibleFriends = item.friends.slice(0, maxVisibleFriends);
+
+          return (
+            <div
+              key={index}
+              className={`${styles.EachLocationWrapper} 
+            ${userSharedLocation === item.name ? styles.HighlightBorder : ""}`}
+            >
+              <div className={styles.EachLocationTitleWrapper}>
+                <img
+                  className={styles.LocationIcon}
+                  src={locationIcon}
+                  alt="핀포인트 아이콘"
+                />
+                <h1 className={styles.EachLocationTitle}>{item.name}</h1>
+              </div>
+
+              <div className={styles.LocationFriendWrapper}>
+                {visibleFriends.map((friend, index) => (
+                  <div key={index} className={styles.EachFriendProfile}>
+                    <img
+                      style={{ width: "49px", height: "49px" }}
+                      src={friend.profileURL || DefaultProfileImg}
+                      alt="프로필 사진"
+                    />
+                    <span className={styles.Nickname}>{friend.nickname}</span>
+                  </div>
+                ))}
+
+                {shouldShowMore && (
+                  <button
+                    className={styles.EachFriendProfile}
+                    onClick={() => console.log("더보기 클릭")}
+                  >
+                    <div className={styles.LearnMoreWrapper}>
+                      <div className={styles.Dotstyle} />
+                      <div className={styles.Dotstyle} />
+                      <div className={styles.Dotstyle} />
+                    </div>
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    )
   );
 };
 

--- a/src/pages/Home/components/HomeMiniMap/HomeMiniMap.tsx
+++ b/src/pages/Home/components/HomeMiniMap/HomeMiniMap.tsx
@@ -12,7 +12,7 @@ interface HomeMiniMapProps {
   isSharedLocation: boolean;
   setModalState: (value: boolean) => void;
   currentLocation: Coordinate;
-  nearLocation: string;
+  sharedLocationName: string | null;
   setNearLocation: (value: string) => void;
 }
 
@@ -20,7 +20,7 @@ const HomeMiniMap: React.FC<HomeMiniMapProps> = ({
   isSharedLocation,
   setModalState,
   currentLocation,
-  nearLocation,
+  sharedLocationName,
   setNearLocation,
 }) => {
   const navigate = useNavigate();
@@ -51,27 +51,29 @@ const HomeMiniMap: React.FC<HomeMiniMapProps> = ({
   return (
     // 내 위치 불러오기 전에 렌더링 안되게. 로딩 표시라도 추가
     isSharedLocation ? (
-      <div className={styles.HomeMiniMapBackground}>
-        <div className={styles.HomeMiniMapWrapper}>
-          <div className={styles.MiniMapTextContainer}>
-            <h1 className={styles.MiniMapBoldText}>
-              현재 {nearLocation}에 계시네요!
-            </h1>
-            <span className={styles.MiniMapNormalText}>
-              장소를 이동할 땐 위치 공유를 해제해주세요 :)
-            </span>
+      sharedLocationName !== null && (
+        <div className={styles.HomeMiniMapBackground}>
+          <div className={styles.HomeMiniMapWrapper}>
+            <div className={styles.MiniMapTextContainer}>
+              <h1 className={styles.MiniMapBoldText}>
+                현재 {sharedLocationName}(으)로 공유 중입니다!
+              </h1>
+              <span className={styles.MiniMapNormalText}>
+                장소를 이동할 땐 위치 공유를 해제해주세요 :)
+              </span>
+            </div>
+            <div className={styles.HomeMiniMap} onClick={handleSeeMap}>
+              <KuroomMap
+                height="180px"
+                isTracking={true}
+                draggable={false}
+                zoomable={false}
+              />
+            </div>
+            <Button onClick={handleOpenModal}>위치 공유 해제하기</Button>
           </div>
-          <div className={styles.HomeMiniMap} onClick={handleSeeMap}>
-            <KuroomMap
-              height="180px"
-              isTracking={true}
-              draggable={false}
-              zoomable={false}
-            />
-          </div>
-          <Button onClick={handleOpenModal}>위치 공유 해제하기</Button>
         </div>
-      </div>
+      )
     ) : (
       <div className={styles.HomeMiniMapBackground}>
         <div className={styles.HomeMiniMapWrapper}>

--- a/src/pages/Map/MapPage.tsx
+++ b/src/pages/Map/MapPage.tsx
@@ -99,7 +99,7 @@ const MapPage = () => {
     try {
       const response = await checkIsSharedApi();
       console.log("현재 내 위치 공유 상태 : ", response);
-      setIsSharedLocation(response);
+      setIsSharedLocation(response.isActive);
     } catch (error) {
       console.error("위치 공유 상태 확인 실패 : ", error);
     }


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 홈 친구위치 관련 api 연동 및 로직 수정

---

## 🔗 관련 이슈

closes #70 

---

## 📷 스크린샷 (필요한 경우)

<img width="360" height="627" alt="image" src="https://github.com/user-attachments/assets/99fd8152-4882-470b-a3a8-f6094b52febb" />
<img width="360" height="645" alt="image" src="https://github.com/user-attachments/assets/2d21a63f-1ef6-4242-a65c-8ff49119fab4" />


---

## 📋 체크리스트

- [x] HomeContent -> FriednLocation에 대한 api 연결
- [x] 내 위치 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 홈 미니맵이 공유 중인 장소명을 직접 표시하며, 공유 중일 때만 안내 블록과 해제 버튼을 노출합니다.
  - 친구 위치 섹션이 실제 API 데이터로 렌더링되어 프로필/목록이 동적으로 표시되고, 사용자 공유 장소와 일치하는 항목을 강조합니다.
- Refactor
  - 공유 상태 확인 시 장소명 포함 상세 정보를 사용하도록 연동을 개선했습니다.
  - 기존 ‘공유 친구 위치’ 전용 조회 기능이 제거되어 해당 항목은 더 이상 제공되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->