### PR TITLE
feat: 이미지 상세보기 구현

### DIFF
--- a/src/assets/nav/image-next-button.svg
+++ b/src/assets/nav/image-next-button.svg
@@ -1,0 +1,4 @@
+<svg width="59" height="59" viewBox="0 0 59 59" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="59" height="59" fill="#1D2228" fill-opacity="0.3"/>
+<path d="M23 42.5L36 29.5L23 16.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/nav/image-prev-button.svg
+++ b/src/assets/nav/image-prev-button.svg
@@ -1,0 +1,4 @@
+<svg width="59" height="59" viewBox="0 0 59 59" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="59" height="59" transform="translate(59 59) rotate(180)" fill="#1D2228" fill-opacity="0.3"/>
+<path d="M36 16.5L23 29.5L36 42.5" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/pages/Map/components/FocusedLocationBottomSheet/FocusedLocationBottomSheet.module.css
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/FocusedLocationBottomSheet.module.css
@@ -38,6 +38,16 @@
   background: #fff;
   overflow-y: scroll;
 }
+.ImageDetails {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background-color: #1d2228;
+}
+.Image {
+  width: 100%;
+  object-fit: contain;
+}
 .SheetIndicator {
   width: 45px;
   height: 5px;

--- a/src/pages/Map/components/FocusedLocationBottomSheet/FocusedLocationBottomSheet.tsx
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/FocusedLocationBottomSheet.tsx
@@ -7,6 +7,7 @@ import { DetailPlaceData } from "@/shared/types";
 import styles from "./FocusedLocationBottomSheet.module.css";
 import LocationInfoTopContent from "./LocationInfoTopContent/LocationInfoTopContent";
 import FocusedLocationInfo from "./FocusedLocationInfo/FocusedLocationInfo";
+import ImageDetails from "./ImageDetails.tsx/ImageDetails";
 
 interface FocusedLocationBottomSheetProps {
   hasFocusedMarker: boolean;
@@ -28,6 +29,20 @@ const FocusedLocationBottomSheet: React.FC<FocusedLocationBottomSheetProps> = ({
 
   // 아직 해당 장소 정보가 안 왔을 때 로딩처리
   const [isLoading, setIsLoading] = useState(true);
+
+  // 사진 자세히 보기 상태
+  const [isImageDetailMode, setIsImageDetailMode] = useState(false);
+  const [clickedIndex, setClickedIndex] = useState(0);
+
+  const handleCloseImageDetail = () => {
+    setIsImageDetailMode(false);
+  };
+
+  const handleOpenSelectImageIndex = (index?: number) => {
+    if (index) setClickedIndex(index);
+    else setClickedIndex(0);
+    setIsImageDetailMode(true);
+  };
 
   // 서버에 해당 장소 정보 요청
   useEffect(() => {
@@ -53,6 +68,7 @@ const FocusedLocationBottomSheet: React.FC<FocusedLocationBottomSheetProps> = ({
     setIsExpanded: setIsExpandedFocusedSheet,
     setHasFocusedMarker: setHasFocusedMarker,
     minHeight: 450,
+    disabled: isImageDetailMode,
   });
 
   return (
@@ -70,38 +86,49 @@ const FocusedLocationBottomSheet: React.FC<FocusedLocationBottomSheetProps> = ({
             : "translateY(calc(100% - 450px))",
         }}
       >
-        <div className={styles.SheetIndicator} />
-        {isLoading ? (
-          <div className={styles.MyPageLoadingWrapper}>
-            <BeatLoader color="#009733" size={18} margin={4} />
-          </div>
+        {isImageDetailMode && detailLocationData?.imageUrls ? (
+          <ImageDetails
+            clickedIndex={clickedIndex}
+            imageUrls={detailLocationData?.imageUrls}
+            handleCloseImageDetail={handleCloseImageDetail}
+          />
         ) : (
           <>
-            {isExpandedFocusedSheet && (
-              <LocationInfoTopContent
-                detailInfo={detailLocationData}
-                setIsExpandedFocusedSheet={setIsExpandedFocusedSheet}
-              />
-            )}
-            <FocusedLocationInfo
-              detailInfo={detailLocationData}
-              isExpandedFocusedSheet={isExpandedFocusedSheet}
-              setIsExpandedFocusedSheet={setIsExpandedFocusedSheet}
-            />
-            {!isExpandedFocusedSheet && (
-              <div className={styles.SheetImgContainer}>
-                {/* 최대 3개까지만 보이도록 */}
-                {detailLocationData?.imageUrls
-                  .slice(0, 3)
-                  .map((item, index) => (
-                    <img
-                      className={styles.SheetImg}
-                      key={index}
-                      src={item}
-                      alt="위치 관련 이미지"
-                    />
-                  ))}
+            <div className={styles.SheetIndicator} />
+            {isLoading ? (
+              <div className={styles.MyPageLoadingWrapper}>
+                <BeatLoader color="#009733" size={18} margin={4} />
               </div>
+            ) : (
+              <>
+                {isExpandedFocusedSheet && (
+                  <LocationInfoTopContent
+                    locationImages={detailLocationData?.imageUrls}
+                    setIsExpandedFocusedSheet={setIsExpandedFocusedSheet}
+                    handleSelectImageIndex={handleOpenSelectImageIndex}
+                  />
+                )}
+                <FocusedLocationInfo
+                  detailInfo={detailLocationData}
+                  isExpandedFocusedSheet={isExpandedFocusedSheet}
+                  setIsExpandedFocusedSheet={setIsExpandedFocusedSheet}
+                />
+                {!isExpandedFocusedSheet && (
+                  <div className={styles.SheetImgContainer}>
+                    {/* 최대 3개까지만 보이도록 */}
+                    {detailLocationData?.imageUrls
+                      .slice(0, 3)
+                      .map((item, index) => (
+                        <img
+                          className={styles.SheetImg}
+                          key={index}
+                          src={item}
+                          alt="위치 관련 이미지"
+                        />
+                      ))}
+                  </div>
+                )}
+              </>
             )}
           </>
         )}

--- a/src/pages/Map/components/FocusedLocationBottomSheet/ImageDetails.tsx/ImageDetails.module.css
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/ImageDetails.tsx/ImageDetails.module.css
@@ -1,0 +1,52 @@
+.Header {
+  position: absolute;
+  width: 100%;
+  top: 0;
+  padding: 40px 30px 20px 30px;
+  z-index: 100;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.StepIndicator {
+  color: white;
+}
+.ImageDetailsPage {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background-color: #1d2228;
+  align-items: center;
+}
+.ImageWrapper {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+.Slider {
+  display: flex;
+  width: 100%;
+  transition: transform 0.3s ease-in-out;
+}
+.Image {
+  min-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+.PrevButton,
+.NextButton {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  cursor: pointer;
+}
+
+.PrevButton {
+  left: -5px;
+}
+
+.NextButton {
+  right: -5px;
+}

--- a/src/pages/Map/components/FocusedLocationBottomSheet/ImageDetails.tsx/ImageDetails.tsx
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/ImageDetails.tsx/ImageDetails.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import ArrowBackIcon from "@assets/nav/arrowBackWhite.svg";
+import ImagePrev from "@assets/nav/image-prev-button.svg";
+import ImageNext from "@assets/nav/image-next-button.svg";
+
+import styles from "./ImageDetails.module.css";
+
+interface ImageDetailsProps {
+  clickedIndex?: number;
+  imageUrls: string[];
+  handleCloseImageDetail: () => void;
+}
+
+export default function ImageDetails({
+  clickedIndex = 0,
+  imageUrls,
+  handleCloseImageDetail,
+}: ImageDetailsProps) {
+  const [currentIndex, setCurrentIndex] = useState(clickedIndex);
+
+  const handlePrev = () => {
+    setCurrentIndex(currentIndex - 1);
+  };
+
+  const handleNext = () => {
+    setCurrentIndex(currentIndex + 1);
+  };
+
+  return (
+    imageUrls && (
+      <div className={styles.ImageDetailsPage}>
+        <header className={styles.Header}>
+          <img
+            src={ArrowBackIcon}
+            alt="내리기"
+            onClick={handleCloseImageDetail}
+          />
+          <span className={styles.StepIndicator}>
+            {currentIndex + 1} / {imageUrls.length}
+          </span>
+        </header>
+        <div className={styles.ImageWrapper}>
+          {currentIndex !== 0 && (
+            <img
+              className={styles.PrevButton}
+              src={ImagePrev}
+              onClick={handlePrev}
+            />
+          )}
+          <div
+            className={styles.Slider}
+            style={{
+              transform: `translateX(-${currentIndex * 100}%)`,
+            }}
+          >
+            {imageUrls.map((img, idx) => (
+              <img
+                key={idx}
+                className={styles.Image}
+                src={img}
+                alt={`상세 이미지 ${idx + 1}`}
+              />
+            ))}
+          </div>
+          {currentIndex + 1 !== imageUrls.length && (
+            <img
+              className={styles.NextButton}
+              src={ImageNext}
+              onClick={handleNext}
+            />
+          )}
+        </div>
+      </div>
+    )
+  );
+}

--- a/src/pages/Map/components/FocusedLocationBottomSheet/LocationInfoTopContent/LocationInfoTopContent.module.css
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/LocationInfoTopContent/LocationInfoTopContent.module.css
@@ -8,11 +8,26 @@
   box-sizing: border-box;
   overflow: hidden;
 }
+.ImgContainer {
+  height: 50vw;
+  width: 100%;
+}
+
+.OneImgContainer {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.TwoImgsContainer {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
 .ImgGridContainer {
   display: grid;
   grid-template-columns: 2fr 2fr;
-  height: 100%;
-  width: 100%;
   box-sizing: border-box;
 }
 .MainImg {

--- a/src/pages/Map/components/FocusedLocationBottomSheet/LocationInfoTopContent/LocationInfoTopContent.tsx
+++ b/src/pages/Map/components/FocusedLocationBottomSheet/LocationInfoTopContent/LocationInfoTopContent.tsx
@@ -3,49 +3,91 @@ import React from "react";
 import arrowBackIcon from "@assets/nav/arrowBackWhite.svg";
 
 import styles from "./LocationInfoTopContent.module.css";
-import { DetailPlaceData } from "@/shared/types";
 
 interface LocationInfoTopContentProps {
-  detailInfo: DetailPlaceData | null;
+  locationImages: string[] | undefined;
   setIsExpandedFocusedSheet: (value: boolean) => void;
+  handleSelectImageIndex: (index: number) => void;
 }
 
 const LocationInfoTopContent: React.FC<LocationInfoTopContentProps> = ({
-  detailInfo,
+  locationImages,
   setIsExpandedFocusedSheet,
+  handleSelectImageIndex,
 }) => {
-  return (
-    <div className={styles.TopContentContainer}>
-      <div className={styles.ImgGridContainer}>
-        <img
-          src={detailInfo?.imageUrls[0]}
-          className={styles.MainImg}
-          alt="대표 이미지"
-        />
-        <div className={styles.SubImgGrid}>
-          {[1, 2, 3, 4].map((i, index) =>
-            detailInfo?.imageUrls[i] ? (
+  const handleSelectMainImage = () => {
+    handleSelectImageIndex(0);
+  };
+  const renderImageComponent = () => {
+    if (locationImages === undefined) return;
+    const imageCount = locationImages.length;
+    switch (imageCount) {
+      case 1:
+        return (
+          <img
+            className={styles.OneImgContainer}
+            src={locationImages[0]}
+            alt="대표 이미지"
+            onClick={handleSelectMainImage}
+          />
+        );
+      case 2:
+        return (
+          <div className={styles.TwoImgsContainer}>
+            {locationImages.map((img, index) => (
               <img
                 key={index}
-                src={detailInfo.imageUrls[i]}
-                className={styles.SubImg}
-                alt={`서브 이미지 ${i}`}
+                src={img}
+                onClick={() => handleSelectImageIndex(index)}
               />
-            ) : (
-              <div key={index} />
-            )
-          )}
+            ))}
+          </div>
+        );
+      default:
+        return (
+          <div className={styles.ImgGridContainer}>
+            <img
+              src={locationImages[0]}
+              className={styles.MainImg}
+              alt="대표 이미지"
+              onClick={handleSelectMainImage}
+            />
+            <div className={styles.SubImgGrid}>
+              {[1, 2, 3, 4].map((i, index) =>
+                locationImages[i] ? (
+                  <img
+                    key={index}
+                    src={locationImages[i]}
+                    className={styles.SubImg}
+                    alt={`서브 이미지 ${i}`}
+                    onClick={() => handleSelectImageIndex(i)}
+                  />
+                ) : (
+                  <div key={index} onClick={handleSelectMainImage} />
+                )
+              )}
+            </div>
+          </div>
+        );
+    }
+  };
+
+  return (
+    locationImages && (
+      <div className={styles.TopContentContainer}>
+        <div className={styles.ImgContainer}>
+          {locationImages.length > 0 && renderImageComponent()}
+        </div>
+        <div className={styles.HeaderGrad} />
+        <div className={styles.HeaderContainer}>
+          <img
+            src={arrowBackIcon}
+            alt="내리기"
+            onClick={() => setIsExpandedFocusedSheet(false)}
+          />
         </div>
       </div>
-      <div className={styles.HeaderGrad} />
-      <div className={styles.HeaderContainer}>
-        <img
-          src={arrowBackIcon}
-          alt="내리기"
-          onClick={() => setIsExpandedFocusedSheet(false)}
-        />
-      </div>
-    </div>
+    )
   );
 };
 

--- a/src/pages/Map/hooks/useBottomSheetDrag.ts
+++ b/src/pages/Map/hooks/useBottomSheetDrag.ts
@@ -7,6 +7,7 @@ interface UseBottomSheetDragProps {
   setIsExpanded: (value: boolean) => void;
   setHasFocusedMarker?: (value: boolean) => void;
   minHeight: number; // 예: 150, 380 등
+  disabled?: boolean;
 }
 
 export default function useBottomSheetDrag({
@@ -16,6 +17,7 @@ export default function useBottomSheetDrag({
   setIsExpanded,
   setHasFocusedMarker,
   minHeight,
+  disabled = false,
 }: UseBottomSheetDragProps) {
   const startY = useRef(0);
   const currentY = useRef(0);
@@ -23,6 +25,8 @@ export default function useBottomSheetDrag({
   const canDrag = useRef(false);
 
   useEffect(() => {
+    if (disabled) return;
+
     const sheet = sheetRef.current;
     if (!sheet) return;
 
@@ -118,5 +122,6 @@ export default function useBottomSheetDrag({
     sheetRef,
     hasFocusedMarker,
     setHasFocusedMarker,
+    disabled,
   ]);
 }

--- a/src/pages/Map/utils/kuroomMapUtils.ts
+++ b/src/pages/Map/utils/kuroomMapUtils.ts
@@ -218,8 +218,6 @@ async function makeFocusMarker(
     position.lng()
   );
 
-  console.log("이거 실행됨!!");
-
   map.setCenter(adjustedPosition);
   map.setZoom(17);
   setIsTracking(false);
@@ -228,7 +226,6 @@ async function makeFocusMarker(
 
   try {
     const response = await getLocationDetailData(placeId);
-    console.log("이게 결과임:", response);
     setDetailLocationData(response);
   } catch (error) {
     console.error("디테일 위치 정보 가져오기 mapUtils에서 오류 : ", error);


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 이미지 개수에 따라 다른 레이아웃 보이도록 분기 처리
- 이미지 상세보기 구현

---

## 🔗 관련 이슈

closes #90 

---

## 📷 스크린샷 (필요한 경우)

<img width="441" height="953" alt="image" src="https://github.com/user-attachments/assets/5a0cc615-14e9-4190-a25f-9322c465a019" />
<img width="434" height="947" alt="image" src="https://github.com/user-attachments/assets/fb9edbae-80e9-4fa0-91f6-3561e0c2164a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 장소 하단 시트에 이미지 상세 보기 모드 추가: 좌우 내비게이션, 단계 표시, 슬라이더로 이미지 감상.
  - 이미지 썸네일 레이아웃 개선(1/2/다중 지원) 및 클릭 시 상세 보기 진입.
  - 상세 보기 중 하단 시트 드래그 비활성화로 조작 안정성 향상.
- Style
  - 이미지 상세/썸네일 영역 전용 스타일 추가로 가독성과 배치 개선.
- Chores
  - 불필요한 콘솔 로그 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->