### PR TITLE
feat: 소셜 로그인 신규 회원 판별 API 연동 완료

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -5,6 +5,7 @@ const LOGOUT_API_URL = "/auth/logout";
 const WITHDRAW_API_URL = "/users/deactivate";
 const REISSUE_TOKEN_API_URL = "/auth/reissue";
 const OAUTH_TOKEN_API_URL = "/auth/token";
+const CREATE_SOCIAL_USER_API_URL = "/api/v1/users/social";
 
 interface LoginResponse {
   code: number;
@@ -140,6 +141,42 @@ export const getTokenByAuthCode = async (authCode: string) => {
     }
     throw new Error(
       error.response?.data?.message || "OAuth 토큰 교환 중 오류 발생"
+    );
+  }
+};
+
+// 소셜 로그인 신규 회원 생성 API
+interface CreateSocialUserRequest {
+  email: string;
+  loginId: string;
+  password: string;
+  studentId: string;
+  department: string;
+  nickname: string;
+  agreementStatus: string;
+}
+
+interface CreateSocialUserResponse {
+  code: number;
+  status: string;
+  message: string;
+}
+
+export const createSocialUserApi = async (
+  userData: CreateSocialUserRequest
+) => {
+  try {
+    const response = await axiosInstance.post<CreateSocialUserResponse>(
+      CREATE_SOCIAL_USER_API_URL,
+      userData,
+      {
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+    return response.data;
+  } catch (error: any) {
+    throw new Error(
+      error.response?.data?.message || "소셜 로그인 회원 생성 중 오류 발생"
     );
   }
 };

--- a/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -63,6 +63,15 @@ const OAuthCallback = () => {
           const redirectUrl = sessionStorage.getItem("redirectUrl") || "/";
           sessionStorage.removeItem("redirectUrl");
           navigate(redirectUrl);
+        } else if (response?.code === 1024) {
+          // 신규 회원인 경우 (code 1024)
+          console.log("신규 회원 감지, 추가 정보 입력 페이지로 이동");
+
+          // authCode를 sessionStorage에 저장하여 나중에 회원가입 완료 시 사용
+          sessionStorage.setItem("socialAuthCode", authCode);
+
+          // 약관 동의 페이지로 이동
+          navigate("/agreement");
         } else {
           console.error("토큰 교환 실패:", response);
           navigate("/login");


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

소셜 로그인(카카오/네이버/구글) 신규 회원 판별 기능을 추가했습니다.

### 주요 변경 사항
- **소셜 로그인 신규 회원 생성 API 추가** (`POST /api/v1/users/social`)
- **OAuthCallback 컴포넌트에 신규 회원 판별 로직 추가**
  - 응답 코드 1024인 경우 신규 회원으로 판별
  - authCode를 sessionStorage에 저장하여 회원가입 완료 시 사용
  - 신규 회원은 `/agreement` 페이지로 리다이렉트

---

## 📋 체크리스트

- [ ] 변경 사항이 정상적으로 동작하는지 확인했습니다.
- [ ] 필요시 관련 문서를 업데이트했습니다.

---

## 💬 하고 싶은 말

### 구현 상세

**1. API 함수 추가** (`src/apis/auth.ts`)
- `createSocialUserApi`: 소셜 로그인 신규 회원 생성 API
- Request: `{ email, loginId, password, studentId, department, nickname, agreementStatus }`
- Response: `{ code, status, message }`

**2. OAuthCallback 로직 수정** (`src/pages/OAuthCallback/OAuthCallback.tsx`)
```typescript
// 기존 회원: `response.data` 존재 → 토큰 저장 후 홈으로 이동
// 신규 회원: `response.code === 1024` → authCode 저장 후 `/agreement`로 이동
// 실패: 그 외 → `/login`으로 이동

### 플로우
1. 소셜 로그인 버튼 클릭 → 백엔드 OAuth 엔드포인트로 리다이렉트
2. 백엔드에서 `/oauth/callback?authCode=xxx`로 리다이렉트
3. getTokenByAuthCode(authCode) 호출
4. **신규 회원(code: 1024):** authCode 저장 → `/agreement` → `/identityverification` → `/profilesetting` 순서로 진행 예정
5. **기존 회원:** 토큰 저장 → 홈으로 이동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 소셜 로그인 후 신규 사용자 감지 시 인증 코드를 안전하게 저장하고 약관 동의 화면(/agreement)으로 자동 이동하는 온보딩 흐름을 추가했습니다.
  * 소셜 사용자 생성 API 연동으로 최초 로그인 사용자의 계정 생성이 원활해졌습니다.
  * 성공 시 토큰 저장·사용자 설정 후 원래 페이지로 이동, 실패 시 로그인 페이지로 안내하는 기존 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->