### PR TITLE
[Feature/#101] 위치 공유 불가 모달 상태 추가

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -36,6 +36,7 @@ const Home = () => {
 
   // 유저의 위치와 가장 가까운 위치 저장할 상태
   const [nearLocation, setNearLocation] = useState("");
+  const [ableToShare, setAbleToShare] = useState(false);
 
   // 내 위치 공유 버튼 모달 상태
   const [shareModalState, setShareModalState] = useState(false);
@@ -110,6 +111,7 @@ const Home = () => {
             currentLocation={currentLocation}
             sharedLocationName={sharedLocationName}
             setNearLocation={setNearLocation}
+            setAbleToShare={setAbleToShare}
           />
         )}
         <FriendLocation userSharedLocation={sharedLocationName} />
@@ -120,6 +122,7 @@ const Home = () => {
       <ShareLocationModal
         modalState={shareModalState}
         isSharedLocation={isSharedLocation}
+        ableToShare={ableToShare}
         nearLocation={nearLocation}
         setModalState={setShareModalState}
         refreshSharedStatus={() =>

--- a/src/pages/Home/components/HomeMiniMap/HomeMiniMap.tsx
+++ b/src/pages/Home/components/HomeMiniMap/HomeMiniMap.tsx
@@ -14,6 +14,7 @@ interface HomeMiniMapProps {
   currentLocation: Coordinate;
   sharedLocationName: string | null;
   setNearLocation: (value: string) => void;
+  setAbleToShare: (value: boolean) => void;
 }
 
 const HomeMiniMap: React.FC<HomeMiniMapProps> = ({
@@ -22,6 +23,7 @@ const HomeMiniMap: React.FC<HomeMiniMapProps> = ({
   currentLocation,
   sharedLocationName,
   setNearLocation,
+  setAbleToShare,
 }) => {
   const navigate = useNavigate();
 
@@ -35,7 +37,10 @@ const HomeMiniMap: React.FC<HomeMiniMapProps> = ({
       console.log(response);
       setNearLocation(response);
       setModalState(true);
+      setAbleToShare(true);
     } catch (error) {
+      setModalState(true);
+      setAbleToShare(false);
       console.error("가장 가까운 위치 조회 실패 : ", error);
     }
   };

--- a/src/pages/Map/MapPage.tsx
+++ b/src/pages/Map/MapPage.tsx
@@ -64,6 +64,7 @@ const MapPage = () => {
     detailLocationData,
     searchMode,
     isInSchool,
+    ableToShare,
     isSharedLocation,
     locationSharedRefreshKey,
     selectedCategoryTitle,
@@ -84,6 +85,7 @@ const MapPage = () => {
     setDetailLocationData,
     setSearchMode,
     setIsInSchool,
+    setAbleToShare,
     setIsSharedLocation,
     setLocationSharedRefreshKey,
     setSelectedCategoryTitle,
@@ -116,7 +118,9 @@ const MapPage = () => {
       );
       console.log(response);
       setNearLocation(response);
+      setAbleToShare(true);
     } catch (error) {
+      setAbleToShare(false);
       console.error("가장 가까운 위치 조회 실패 : ", error);
     }
   };
@@ -456,6 +460,7 @@ const MapPage = () => {
       <ShareLocationModal
         modalState={modalState}
         isSharedLocation={isSharedLocation}
+        ableToShare={ableToShare}
         nearLocation={nearLocation}
         setModalState={setModalState}
         refreshSharedStatus={() =>

--- a/src/pages/Map/layout/MapLayout.tsx
+++ b/src/pages/Map/layout/MapLayout.tsx
@@ -26,6 +26,8 @@ export interface MapLayoutContext {
   searchMode: boolean;
   /** 현재 위치가 학교 내부인지 여부 */
   isInSchool: boolean;
+  // 위치 공유 가능한지 상태
+  ableToShare: boolean;
   /** 내 위치 공유 상태 */
   isSharedLocation: boolean;
   /** 위치 공유 상태 갱신 트리거 키 */
@@ -60,6 +62,7 @@ export interface MapLayoutContext {
   >;
   setSearchMode: React.Dispatch<React.SetStateAction<boolean>>;
   setIsInSchool: React.Dispatch<React.SetStateAction<boolean>>;
+  setAbleToShare: React.Dispatch<React.SetStateAction<boolean>>;
   setIsSharedLocation: React.Dispatch<React.SetStateAction<boolean>>;
   setLocationSharedRefreshKey: React.Dispatch<React.SetStateAction<number>>;
   setSelectedCategoryTitle: React.Dispatch<React.SetStateAction<string>>;
@@ -85,6 +88,7 @@ const MapLayout = () => {
 
   const [searchMode, setSearchMode] = useState(false);
   const [isInSchool, setIsInSchool] = useState(false);
+  const [ableToShare, setAbleToShare] = useState(false);
   const [isSharedLocation, setIsSharedLocation] = useState(false);
   const [locationSharedRefreshKey, setLocationSharedRefreshKey] = useState(0);
   const [selectedCategoryTitle, setSelectedCategoryTitle] =
@@ -112,6 +116,7 @@ const MapLayout = () => {
         detailLocationData,
         searchMode,
         isInSchool,
+        ableToShare,
         isSharedLocation,
         locationSharedRefreshKey,
         selectedCategoryTitle,
@@ -131,6 +136,7 @@ const MapLayout = () => {
         setDetailLocationData,
         setSearchMode,
         setIsInSchool,
+        setAbleToShare,
         setIsSharedLocation,
         setLocationSharedRefreshKey,
         setSelectedCategoryTitle,

--- a/src/shared/components/ShareLocationModal/ShareLocationModal.tsx
+++ b/src/shared/components/ShareLocationModal/ShareLocationModal.tsx
@@ -10,6 +10,7 @@ import styles from "./ShareLocationModal.module.css";
 interface ShareLocationModalProps {
   modalState: boolean;
   isSharedLocation: boolean;
+  ableToShare: boolean;
   nearLocation: string;
   setModalState: React.Dispatch<React.SetStateAction<boolean>>;
   refreshSharedStatus: () => void;
@@ -19,6 +20,7 @@ interface ShareLocationModalProps {
 const ShareLocationModal: React.FC<ShareLocationModalProps> = ({
   modalState,
   isSharedLocation,
+  ableToShare,
   nearLocation,
   setModalState,
   refreshSharedStatus,
@@ -30,7 +32,6 @@ const ShareLocationModal: React.FC<ShareLocationModalProps> = ({
   const handleSharingLocation = async () => {
     try {
       const response = await shareUserLocation(nearLocation);
-      console.log("서버에 내 위치 공유 요청");
       console.log(response);
 
       refreshSharedStatus();
@@ -72,6 +73,13 @@ const ShareLocationModal: React.FC<ShareLocationModalProps> = ({
               친구들에게 현재 위치가 보이지 않게 됩니다.
             </span>
           </>
+        ) : !ableToShare ? (
+          <>
+            <span className={styles.BoldText}>위치 공유가 불가합니다.</span>
+            <span className={styles.AdditionalInform}>
+              학교 건물 안에서 위치 공유를 시도해주세요.
+            </span>
+          </>
         ) : (
           <>
             <span className={styles.InformText}>
@@ -87,17 +95,27 @@ const ShareLocationModal: React.FC<ShareLocationModalProps> = ({
         )}
       </div>
       <div className={styles.ButtonWrapper}>
-        <Button variant="tertiary" onClick={handleCloseModal} size="sm">
-          취소
-        </Button>
-        <Button
-          onClick={
-            isSharedLocation ? handleUnSharingLocation : handleSharingLocation
-          }
-          size="sm"
-        >
-          확인
-        </Button>
+        {!isSharedLocation && !ableToShare ? (
+          <Button onClick={handleCloseModal} size="sm">
+            확인
+          </Button>
+        ) : (
+          <>
+            <Button variant="tertiary" onClick={handleCloseModal} size="sm">
+              취소
+            </Button>
+            <Button
+              onClick={
+                isSharedLocation
+                  ? handleUnSharingLocation
+                  : handleSharingLocation
+              }
+              size="sm"
+            >
+              확인
+            </Button>
+          </>
+        )}
       </div>
     </ReactModal>
   );


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 위치 공유 시도할 때 위치 공유 불가 상태 모달 추가

---

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 적어주세요. -->

closes #101 

---

## 📷 스크린샷 (필요한 경우)
<img width="442" height="543" alt="image" src="https://github.com/user-attachments/assets/3de404b9-3768-4841-9a51-e5f56960aa00" />

<img width="443" height="435" alt="image" src="https://github.com/user-attachments/assets/4f1a6f38-eb16-452c-a8e8-0aa21f1bb0de" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 앱이 사용자의 현재 위치에서 공유 가능 여부를 자동으로 판별하고 홈/지도 화면에서 이를 반영합니다.
  - 위치 공유 모달이 공유 가능 여부에 따라 동적으로 동작합니다.

- UX 개선
  - 공유가 불가능할 때 안내 메시지와 단일 확인 버튼을 제공해 명확한 피드백을 제공합니다.
  - 공유가 가능할 때는 기존의 취소/확인 흐름을 유지하며, 공유/해제 결과가 즉시 화면에 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->