### PR TITLE
fix: 소셜 로그인 리다이렉트 URI를 Vercel 배포 주소로 변경

### DIFF
--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -83,8 +83,7 @@ const Login = () => {
     // 현재 페이지 저장 (로그인 후 돌아올 위치)
     sessionStorage.setItem("redirectUrl", "/");
 
-    // 로컬 개발 환경에서는 localhost로 리다이렉트
-    const redirectUri = window.location.origin;
+    const redirectUri = "https://ku-room.vercel.app/oauth/callback";
 
     // 구글 OAuth2 엔드포인트로 리다이렉트
     window.location.href = `https://kuroom.shop/oauth2/authorization/google?redirect_uri=${redirectUri}`;
@@ -95,8 +94,7 @@ const Login = () => {
     // 현재 페이지 저장 (로그인 후 돌아올 위치)
     sessionStorage.setItem("redirectUrl", "/");
 
-    // 로컬 개발 환경에서는 localhost로 리다이렉트
-    const redirectUri = window.location.origin;
+    const redirectUri = "https://ku-room.vercel.app/oauth/callback";
 
     // 카카오 OAuth2 엔드포인트로 리다이렉트
     window.location.href = `https://kuroom.shop/oauth2/authorization/kakao?redirect_uri=${redirectUri}`;
@@ -107,8 +105,7 @@ const Login = () => {
     // 현재 페이지 저장 (로그인 후 돌아올 위치)
     sessionStorage.setItem("redirectUrl", "/");
 
-    // 로컬 개발 환경에서는 localhost로 리다이렉트
-    const redirectUri = window.location.origin;
+    const redirectUri = "https://ku-room.vercel.app/oauth/callback";
 
     // 네이버 OAuth2 엔드포인트로 리다이렉트
     window.location.href = `https://kuroom.shop/oauth2/authorization/naver?redirect_uri=${redirectUri}`;


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

소셜 로그인(카카오, 네이버, 구글) 리다이렉트 URI를 Vercel 배포 주소로 변경했습니다.
- 기존: `window.location.origin` (로컬/프로덕션 환경에 따라 동적 변경)
- 변경: `https://ku-room.vercel.app/oauth/callback` (고정)

---

## 🔗 관련 이슈

closes #109 

---

## 💬 하고 싶은 말

소셜 로그인 OAuth 콜백 처리를 위해 리다이렉트 URI를 Vercel 배포 도메인으로 통일했습니다.

변경된 파일:
- `src/pages/Login/Login.tsx` (86, 97, 108번째 줄)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 소셜 로그인(Google, Kakao, Naver) 완료 후 리다이렉트 대상이 일관되지 않던 문제를 해소하고, 고정된 콜백 URL로 안정적으로 이동하도록 개선했습니다.
  * 로그인 전 저장된 redirectUrl/세션 정보 사용 흐름은 그대로 유지되어, 인증 후 원래 이동하려던 페이지로 정상적으로 돌아갈 수 있습니다.
  * 다양한 접속 환경(도메인/프로토콜)에 상관없이 동일한 리다이렉트 동작을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->