### PR TITLE
[Refactor/166] 소셜 로그인 시에도 닉네임 변경 가능하도록 수정

### DIFF
--- a/src/shared/constant/sectionDatas.ts
+++ b/src/shared/constant/sectionDatas.ts
@@ -22,7 +22,7 @@ const getProfileChangeSectionData = (loginType: LoginType) => {
       title: "프로필",
       contents:
         loginType === "social"
-          ? ["이메일"]
+          ? ["이메일", "닉네임 변경하기"]
           : ["이메일", "아이디", "비밀번호 변경하기", "닉네임 변경하기"],
     },
     {


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 소셜 로그인 시에도 닉네임 변경 가능하도록 수정

```
const getProfileChangeSectionData = (loginType: LoginType) => {
  return [
    {
      // TODO: 소셜로그인일 때 이메일, 아이디, 비밀번호 변경하기 안보이도록 처리해야함
      title: "프로필",
      contents:
        loginType === "social"
          ? ["이메일", "닉네임 변경하기"]
          : ["이메일", "아이디", "비밀번호 변경하기", "닉네임 변경하기"],
    },
    {
      title: "개인정보",
      contents: ["학번", "학과"],
    },
  ];
};
```

---

## 🔗 관련 이슈

closes #166 

---

## 📷 스크린샷 (필요한 경우)

<img width="441" height="748" alt="image" src="https://github.com/user-attachments/assets/6f8f0603-f1cf-493f-a852-1a42af962328" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 소셜 로그인 사용자가 프로필 설정에서 닉네임 변경 기능에 접근할 수 있도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->