### PR TITLE
KUROOM-67: 공지사항 검색 후 결과 클릭 시 공지사항 페이지로 가도록 수정

### DIFF
--- a/src/pages/Notice/Search/Search.tsx
+++ b/src/pages/Notice/Search/Search.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 import Header from "@components/Header/Header";
 import useToast from "@/shared/hooks/use-toast";
@@ -26,6 +27,7 @@ import type { NoticeResponse } from "@apis/notice";
 import styles from "./Search.module.css";
 
 const Search: React.FC = () => {
+  const navigate = useNavigate();
   const toast = useToast();
   const [searchText, setSearchText] = useState("");
   const [popularNotices, setPopularNotices] = useState<NoticeResponse[]>([]);
@@ -153,8 +155,8 @@ const Search: React.FC = () => {
       ...filteredNotices,
     ];
     const notice = allNotices.find((n) => n.id === noticeId);
-    if (notice?.link) {
-      window.open(notice.link, "_blank");
+    if (notice) {
+      navigate(`/notice/${notice.categoryName}/${notice.id}`);
     }
   };
 


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

검색 페이지에서 공지사항을 클릭했을 때 외부 링크로 바로 이동하는 대신, 공지사항 상세페이지로 이동하도록 수정했습니다.

### 변경 사항
1. `Search.tsx` - `useNavigate` import 추가
2. `Search.tsx` - `navigate` 훅 사용
3. `Search.tsx` - `navigateToNoticeDetail` 함수를 외부 링크 대신 `/notice/:category/:id` 경로로 navigate하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 공지사항 검색 결과에서 항목 선택 시 새 창 대신 애플리케이션 내에서 상세 페이지로 이동하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->