### PR TITLE
[Fix/#190] 학교 내부가 아닐 때, 위치 공유 페이지로 이동하는 버튼 보이지 않도록 수정

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -25,7 +25,7 @@ const Home = () => {
   // const [showSplash, setShowSplash] = useState(true);
   const [isSharedLocation, setIsSharedLocation] = useState(false); // 내 위치 공유상태인지 아닌지
   const [sharedLocationName, setSharedLocationName] = useState<string | null>(
-    null
+    null,
   );
   // 공유 상태 확인 트리거 키
   const [locationSharedRefreshKey, setLocationSharedRefreshKey] = useState(0);
@@ -42,7 +42,7 @@ const Home = () => {
   // 내 위치 공유 버튼 모달 상태
   const [shareModalState, setShareModalState] = useState(false);
   const [currentLocation, setCurrentLocation] = useState<Coordinate | null>(
-    null
+    null,
   ); // 현재 위치
 
   const [tryToRerender, setTryToRerender] = useState(false);
@@ -109,13 +109,7 @@ const Home = () => {
       <div className={styles.HomeContentWrapper}>
         <HomeSildeBanner />
         <HomeMenu />
-        {/* {isInSchool && (
-          <HomeMiniMap
-            isSharedLocation={isSharedLocation}
-            setModalState={setShareModalState}
-          />
-        )} */}
-        {currentLocation !== null && (
+        {isInSchool && currentLocation !== null && (
           <HomeMiniMap
             isSharedLocation={isSharedLocation}
             setModalState={setShareModalState}

--- a/src/pages/Map/MapPage.tsx
+++ b/src/pages/Map/MapPage.tsx
@@ -182,7 +182,7 @@ const MapPage = () => {
     if (!isExpandedSheet) return;
     // 다음 frame에 마커 포커스하기
     const target = renderedMarkers.find(
-      ({ marker }) => marker.getTitle() === location
+      ({ marker }) => marker.getTitle() === location,
     );
     if (target && mapInstanceRef.current) {
       setHasFocusedMarker(true);
@@ -191,7 +191,7 @@ const MapPage = () => {
         target.marker,
         setIsTracking,
         setHasFocusedMarker,
-        setDetailLocationData
+        setDetailLocationData,
       );
     }
 
@@ -234,7 +234,7 @@ const MapPage = () => {
         searchResult.name,
         setIsTracking,
         setHasFocusedMarker,
-        setDetailLocationData
+        setDetailLocationData,
       );
     }
   };
@@ -288,7 +288,7 @@ const MapPage = () => {
         selectedCategoryLocations,
         setIsTracking,
         setHasFocusedMarker,
-        setDetailLocationData
+        setDetailLocationData,
       );
     }
   }, [renderedMarkers]);
@@ -318,7 +318,7 @@ const MapPage = () => {
           longitude: item.longitude,
           isFriendMarker: true,
           numOfFriends: item.friends.length,
-        })
+        }),
       );
       setMarkers(placeMarkers);
       setMarkerFlag((prev) => prev + 1);
@@ -331,7 +331,7 @@ const MapPage = () => {
           name: item.name,
           latitude: item.latitude,
           longitude: item.longitude,
-        })
+        }),
       );
       setMarkers(placeMarkers);
       setMarkerFlag((prev) => prev + 1);
@@ -415,22 +415,6 @@ const MapPage = () => {
                   style={{ filter: isTracking ? "none" : "grayscale(100%)" }}
                 />
               </button>
-              {/* 학교 내부에서만 보이도록 하기! */}
-              {/* 내 위치 공유 버튼 */}
-              {/* {isInSchool && currentLocation !== null && (
-                <button
-                  className={styles.SharedLocationButton}
-                  onClick={handleShareLocation}
-                >
-                  <img src={shareLocationIcon} alt="위치 공유 아이콘" />
-                  {isSharedLocation ? (
-                    <span className={styles.SharingText}>내 위치 공유 중</span>
-                  ) : (
-                    <span className={styles.SharingText}>내 위치 공유</span>
-                  )}
-                </button>
-              )} */}
-              {/* 현재 위치를 가져온 다음에만 렌더링 되도록 */}
               {currentLocation !== null &&
                 (isSharedLocation ? (
                   <button
@@ -444,13 +428,15 @@ const MapPage = () => {
                     <span>내 위치 공유 중</span>
                   </button>
                 ) : (
-                  <button
-                    className={styles.SharedLocationButton}
-                    onClick={handleShareLocation}
-                  >
-                    <img src={shareLocationIcon} alt="위치 공유 아이콘" />
-                    <span>내 위치 공유</span>
-                  </button>
+                  isInSchool && (
+                    <button
+                      className={styles.SharedLocationButton}
+                      onClick={handleShareLocation}
+                    >
+                      <img src={shareLocationIcon} alt="위치 공유 아이콘" />
+                      <span>내 위치 공유</span>
+                    </button>
+                  )
                 ))}
             </>
           )}


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 학교 내부가 아닐 때, 위치 공유 페이지로 이동하는 버튼 보이지 않도록 수정

---

## 🔗 관련 이슈

closes #190 

---

## 📷 스크린샷 (필요한 경우)

<img width="409" height="111" alt="image" src="https://github.com/user-attachments/assets/58338223-038c-493f-9de2-b5a7a4ab953a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 위치 공유 버튼이 학교 내에서만 표시되도록 수정되었습니다.
  * 미니맵 표시 조건이 강화되어 현재 위치 정보가 필요합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->