### PR TITLE
[Fix/#195] 프로필 이미지 변경 api

### DIFF
--- a/src/pages/MyPage/hooks/use-profile-image.ts
+++ b/src/pages/MyPage/hooks/use-profile-image.ts
@@ -19,9 +19,9 @@ export default function useProfileImage() {
 
   const { mutate: updateProfileImage } = useMutation({
     mutationFn: (imageUrl: string | null) => updateProfileImageApi(imageUrl),
-    onSuccess: (response) => {
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: MYPAGE_QUERY_KEY.USER_PROFILE });
-      toast.info(response.message);
+      toast.info("이미지가 성공적으로 변경되었습니다.");
     },
     onError: (error) => {
       const message = error instanceof Error ? error.message : "unknown error";


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- 프로필 이미지 변경 api 서버 문제 해결됨
- 이미지 변경 성공 시 토스트 메시지 수정

---

## 🔗 관련 이슈

closes #195 

---

## 📷 스크린샷 (필요한 경우)

<img width="390" height="625" alt="image" src="https://github.com/user-attachments/assets/b13c5f53-b2c0-4548-8d3b-2575773d07e2" />
<img width="390" height="624" alt="image" src="https://github.com/user-attachments/assets/1181664b-d1f8-4338-aa5e-e277a22db114" />
<img width="393" height="265" alt="image" src="https://github.com/user-attachments/assets/2fd43f82-1353-445b-8110-4c0027ca566c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로필 이미지 기능의 성공 메시지 처리 로직을 개선했습니다. 성공 시 고정된 메시지가 표시되도록 변경되었으며, 쿼리 무효화 및 에러 처리 흐름은 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->