### PR TITLE
[Style/#257] PWA 가이드 페이지 아래쪽 패딩 추가

### DIFF
--- a/src/pages/PwaGuide/PwaGuide.module.css
+++ b/src/pages/PwaGuide/PwaGuide.module.css
@@ -50,7 +50,7 @@
 .Bottom {
   display: flex;
   justify-content: center;
-  padding: 24px 0;
+  padding: 24px 0 120px 0;
 }
 
 .DismissText {


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

- PWA 가이드 페이지 아래쪽 패딩 추가

---

## 🔗 관련 이슈

closes #257 

---

## 📷 스크린샷 (필요한 경우)

<img width="540" height="957" alt="image" src="https://github.com/user-attachments/assets/7dc31959-896b-402c-ba20-4ac48fd1b2f8" />
