### PR TITLE
KUROOM-84: 북마크 토글 시 진입 경로별 상세 캐시 불일치로 헤더 북마크 상태 미반영 문제 수정

### DIFF
--- a/src/pages/Notice/NoticeDetail/hooks/useNoticeDetail.ts
+++ b/src/pages/Notice/NoticeDetail/hooks/useNoticeDetail.ts
@@ -5,7 +5,7 @@ export const useNoticeDetail = (
   category: string | undefined,
 ) => {
   const { noticeDetailData, isPendingNoticeDetail, isErrorNoticeDetail } = useNoticeDetailQuery(id, category);
-  const { toggleBookmark } = useNoticeBookmarkMutation(id, category);
+  const { toggleBookmark } = useNoticeBookmarkMutation(id);
 
   const handleBookmarkToggle = () => {
     if (!noticeDetailData) return;


### PR DESCRIPTION
## ✨ 무엇을 변경했나요?

공지사항 상세 페이지에서 북마크를 토글한 후, 북마크 페이지를 통해 동일한 공지사항의 상세로 재진입 시 헤더의 북마크 아이콘 상태가 반영되지 않던 버그를 수정했습니다.

**원인**

공지사항 상세 페이지는 두 가지 경로로 진입할 수 있습니다.
- 공지 목록 → `/notice/:category/:id` → 쿼리 키: `["notices", "detail", id, category]`
- 북마크 페이지 → `/notice/:id` (category 없음) → 쿼리 키: `["notices", "detail", id, undefined]`

두 경로는 쿼리 키가 달라 React Query가 **별개의 캐시 엔트리**로 관리합니다. 기존 코드의 `setQueryData`는 현재 진입 경로의 키 하나만 업데이트하므로, 다른 경로로 생성된 캐시 엔트리는 staleTime(5분) 동안 갱신되지 않아 이전 북마크 상태를 그대로 보여주는 문제가 발생했습니다.

**수정 내용**

`setQueryData` → `setQueriesData` + `predicate`로 교체하여 동일한 `id`를 가진 모든 상세 캐시를 한 번에 업데이트합니다. 이로써 진입 경로(category 유무)에 상관없이 북마크 상태가 즉시 동기화됩니다.

또한 `useNoticeBookmarkMutation`의 `category` 파라미터는 `setQueryData`에서만 사용되었으므로, 수정과 함께 불필요해진 파라미터를 함께 제거했습니다.

---

## 💬 하고 싶은 말

React Query에서 동일한 데이터를 다른 파라미터 조합으로 여러 번 캐싱하는 경우, 뮤테이션 후 특정 키만 업데이트하면 다른 키의 캐시는 stale 상태로 남을 수 있습니다. `setQueriesData`와 `predicate`를 조합해 부분 키 매칭으로 관련 캐시를 일괄 갱신하는 패턴을 적용했습니다.
